### PR TITLE
Correct mistakes with double quotes.

### DIFF
--- a/rene
+++ b/rene
@@ -7,11 +7,11 @@ GOOD=$1
 
 #GOOD=$(echo $GOOD | tr [:upper:] [:lower:])
 
-if [ $GOOD = 'yes' ] || [ $GOOD = 'YES' ]
+if [ "$GOOD" = 'yes' ] || [ "$GOOD" = 'YES' ]
 then
 	echo that\'s nice
 	exit 0
-elif [ $GOOD = 'no' ] || [ $GOOD = 'NO' ]
+elif [ "$GOOD" = 'no' ] || [ "$GOOD" = 'NO' ]
 then 
 	echo that\'s not so nice
 	exit 0


### PR DESCRIPTION
We need to use double quotes for variables to prevent globbing and word splitting